### PR TITLE
Add OpenID Connect SSO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,8 @@ TRACECAT__DB_URI=postgresql+psycopg://${TRACECAT__POSTGRES_USER}:${TRACECAT__POS
 # First user to promote to superadmin
 TRACECAT__AUTH_SUPERADMIN_EMAIL=
 
-# One or more comma-separated values from `basic`, `google_oauth`, `saml`
-TRACECAT__AUTH_TYPES=basic,google_oauth
+# One or more comma-separated values from `basic`, `google_oauth`, `saml`, `oidc`
+TRACECAT__AUTH_TYPES=basic,google_oauth,oidc
 # One or more comma-separated domains, e.g. `example.com,example.org`
 # Leave blank to allow all domains
 TRACECAT__AUTH_ALLOWED_DOMAINS=
@@ -75,6 +75,7 @@ TRACECAT__AUTH_MIN_PASSWORD_LENGTH=12
 # OAuth
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
+OIDC_DISCOVERY_URL=
 USER_AUTH_SECRET=your-auth-secret
 
 # SAML SSO settings

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -3047,6 +3047,45 @@ paths:
       security:
       - APIKeyCookie: []
       - APIKeyHeader: []
+  /settings/oidc:
+    get:
+      tags:
+      - settings
+      summary: Get Oidc Settings
+      operationId: settings-get_oidc_settings
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OIDCSettingsRead'
+      security:
+      - APIKeyCookie: []
+      - APIKeyHeader: []
+    patch:
+      tags:
+      - settings
+      summary: Update Oidc Settings
+      operationId: settings-update_oidc_settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OIDCSettingsUpdate'
+        required: true
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - APIKeyCookie: []
+      - APIKeyHeader: []
   /settings/app:
     get:
       tags:
@@ -4827,6 +4866,99 @@ paths:
           description: Bad Request
         '422':
           description: Validation Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/HTTPValidationError'
+  /auth/oidc/authorize:
+    get:
+      tags:
+      - auth
+      summary: Oidc:Database.Authorize
+      operationId: auth-oidc:database.authorize
+      parameters:
+      - name: scopes
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Scopes
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2AuthorizeResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/oidc/callback:
+    get:
+      tags:
+      - auth
+      summary: Oidc:Database.Callback
+      description: The response varies based on the authentication backend used.
+      operationId: auth-oidc:database.callback
+      parameters:
+      - name: code
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code
+      - name: code_verifier
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code Verifier
+      - name: state
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: State
+      - name: error
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '400':
+          content:
+            application/json:
+              examples:
+                INVALID_STATE_TOKEN:
+                  summary: Invalid state token.
+                LOGIN_BAD_CREDENTIALS:
+                  summary: User is inactive.
+                  value:
+                    detail: LOGIN_BAD_CREDENTIALS
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+          description: Bad Request
+        '422':
+          description: Validation Error
           content:
             application/json:
               schema:
@@ -6430,6 +6562,36 @@ components:
       type: object
       title: OAuthSettingsUpdate
       description: Settings for OAuth authentication.
+    OIDCSettingsRead:
+      properties:
+        oidc_enabled:
+          type: boolean
+          title: Oidc Enabled
+        oidc_discovery_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Oidc Discovery Url
+      type: object
+      required:
+      - oidc_enabled
+      title: OIDCSettingsRead
+      description: Settings for OpenID Connect authentication.
+    OIDCSettingsUpdate:
+      properties:
+        oidc_enabled:
+          type: boolean
+          title: Oidc Enabled
+          description: Whether OIDC is enabled.
+          default: false
+        oidc_discovery_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Oidc Discovery Url
+      type: object
+      title: OIDCSettingsUpdate
+      description: Settings for OpenID Connect authentication.
     OrgMemberRead:
       properties:
         user_id:

--- a/docs/self-hosting/authentication/oidc.mdx
+++ b/docs/self-hosting/authentication/oidc.mdx
@@ -1,0 +1,31 @@
+---
+title: OpenID Connect
+description: Learn how to authenticate into Tracecat using OpenID Connect.
+icon: shield-keyhole
+---
+
+## Configuration
+
+Set `TRACECAT__AUTH_TYPES` to include `oidc`.
+
+```bash
+TRACECAT__AUTH_TYPES=oidc
+```
+
+## Instructions
+
+<Steps>
+  <Step title="Create an OIDC app in your provider">
+    Register a new application and obtain the client ID and secret.
+    Set the redirect URL to `<your-domain>/auth/oidc/callback`.
+  </Step>
+  <Step title="Configure environment variables in Tracecat">
+    Set the following in your `.env` file:
+    - `OAUTH_CLIENT_ID`
+    - `OAUTH_CLIENT_SECRET`
+    - `OIDC_DISCOVERY_URL`
+  </Step>
+  <Step title="Restart Tracecat">
+    Run `docker compose up`.
+  </Step>
+</Steps>

--- a/docs/self-hosting/authentication/overview.mdx
+++ b/docs/self-hosting/authentication/overview.mdx
@@ -29,6 +29,7 @@ Tracecat currently supports the following authentication methods:
 - `basic`: Email and Password
 - `google_oauth`: Google OAuth
 - `saml`: SAML SSO
+- `oidc`: OpenID Connect
 
 Choose from a number of authentication methods listed below to get started.
 
@@ -53,5 +54,12 @@ Choose from a number of authentication methods listed below to get started.
     href="/self-hosting/authentication/saml-sso"
   >
     Learn how to authenticate into Tracecat using SAML SSO.
+  </Card>
+  <Card
+    title="OpenID Connect"
+    icon="shield-keyhole"
+    href="/self-hosting/authentication/oidc"
+  >
+    Learn how to authenticate into Tracecat using OpenID Connect.
   </Card>
 </CardGroup>

--- a/frontend/src/app/auth/oidc/callback/route.ts
+++ b/frontend/src/app/auth/oidc/callback/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { buildUrl } from "@/lib/ss-utils"
+
+export const GET = async (request: NextRequest) => {
+  console.log("GET /auth/oidc/callback")
+  const url = new URL(buildUrl("/auth/oidc/callback"))
+  url.search = request.nextUrl.search
+
+  const response = await fetch(url.toString())
+  const setCookieHeader = response.headers.get("set-cookie")
+
+  const resp = await fetch(buildUrl("/info"))
+  const { public_app_url } = await resp.json()
+  console.log("Public app URL", public_app_url)
+
+  if (!setCookieHeader) {
+    console.error("No set-cookie header found in response")
+    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+  }
+
+  const redirectResponse = NextResponse.redirect(new URL("/", public_app_url))
+  redirectResponse.headers.set("set-cookie", setCookieHeader)
+  return redirectResponse
+}

--- a/frontend/src/app/organization/settings/oidc/layout.tsx
+++ b/frontend/src/app/organization/settings/oidc/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "OIDC | Organization",
+}
+
+export default function OIDCLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/oidc/page.tsx
+++ b/frontend/src/app/organization/settings/oidc/page.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { OrgSettingsOidcForm } from "@/components/organization/org-settings-oidc"
+
+export default function OidcSettingsPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">OIDC Settings</h2>
+            <p className="text-md text-muted-foreground">
+              View and manage your organization OIDC settings here.
+            </p>
+          </div>
+        </div>
+
+        <OrgSettingsOidcForm />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3522,6 +3522,41 @@ export const $OAuthSettingsUpdate = {
   description: "Settings for OAuth authentication.",
 } as const
 
+export const $OIDCSettingsRead = {
+  properties: {
+    oidc_enabled: {
+      type: "boolean",
+      title: "Oidc Enabled",
+    },
+    oidc_discovery_url: {
+      anyOf: [{ type: "string" }, { type: "null" }],
+      title: "Oidc Discovery Url",
+    },
+  },
+  type: "object",
+  required: ["oidc_enabled"],
+  title: "OIDCSettingsRead",
+  description: "Settings for OpenID Connect authentication.",
+} as const
+
+export const $OIDCSettingsUpdate = {
+  properties: {
+    oidc_enabled: {
+      type: "boolean",
+      title: "Oidc Enabled",
+      description: "Whether OIDC is enabled.",
+      default: false,
+    },
+    oidc_discovery_url: {
+      anyOf: [{ type: "string" }, { type: "null" }],
+      title: "Oidc Discovery Url",
+    },
+  },
+  type: "object",
+  title: "OIDCSettingsUpdate",
+  description: "Settings for OpenID Connect authentication.",
+} as const
+
 export const $OrgMemberRead = {
   properties: {
     user_id: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -2538,6 +2538,40 @@ export const settingsUpdateOauthSettings = (
 }
 
 /**
+ * Get Oidc Settings
+ * @returns OIDCSettingsRead Successful Response
+ * @throws ApiError
+ */
+export const settingsGetOidcSettings =
+  (): CancelablePromise<SettingsGetOidcSettingsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/settings/oidc",
+    })
+  }
+
+/**
+ * Update Oidc Settings
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const settingsUpdateOidcSettings = (
+  data: SettingsUpdateOidcSettingsData
+): CancelablePromise<SettingsUpdateOidcSettingsResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/settings/oidc",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * Get App Settings
  * @returns AppSettingsRead Successful Response
  * @throws ApiError

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3422,6 +3422,27 @@ export type SettingsUpdateOauthSettingsData = {
 
 export type SettingsUpdateOauthSettingsResponse = void
 
+export type OIDCSettingsRead = {
+  oidc_enabled: boolean
+  oidc_discovery_url?: string | null
+}
+
+export type OIDCSettingsUpdate = {
+  /**
+   * Whether OIDC is enabled.
+   */
+  oidc_enabled?: boolean
+  oidc_discovery_url?: string | null
+}
+
+export type SettingsGetOidcSettingsResponse = OIDCSettingsRead
+
+export type SettingsUpdateOidcSettingsData = {
+  requestBody: OIDCSettingsUpdate
+}
+
+export type SettingsUpdateOidcSettingsResponse = void
+
 export type SettingsGetAppSettingsResponse = AppSettingsRead
 
 export type SettingsUpdateAppSettingsData = {

--- a/frontend/src/components/organization/org-settings-oidc.tsx
+++ b/frontend/src/components/organization/org-settings-oidc.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { OIDCSettingsUpdate } from "@/client"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useAppInfo, useOrgOidcSettings } from "@/lib/hooks"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+
+const oidcFormSchema = z.object({
+  oidc_enabled: z.boolean(),
+  oidc_discovery_url: z.string().url().nullish(),
+})
+
+type OidcFormValues = z.infer<typeof oidcFormSchema>
+
+export function OrgSettingsOidcForm() {
+  const { appInfo } = useAppInfo()
+  const {
+    oidcSettings,
+    oidcSettingsIsLoading,
+    oidcSettingsError,
+    updateOidcSettings,
+    updateOidcSettingsIsPending,
+  } = useOrgOidcSettings()
+
+  const form = useForm<OidcFormValues>({
+    resolver: zodResolver(oidcFormSchema),
+    values: {
+      oidc_enabled: oidcSettings?.oidc_enabled ?? false,
+      oidc_discovery_url: oidcSettings?.oidc_discovery_url,
+    },
+  })
+
+  const isOidcAllowed = appInfo?.auth_allowed_types.includes("oidc")
+  const onSubmit = async (data: OidcFormValues) => {
+    const conditional: Partial<OIDCSettingsUpdate> = {
+      oidc_discovery_url: data.oidc_discovery_url ?? undefined,
+    }
+    if (isOidcAllowed) {
+      conditional.oidc_enabled = data.oidc_enabled
+    }
+    try {
+      await updateOidcSettings({
+        requestBody: conditional,
+      })
+    } catch {
+      console.error("Failed to update oidc settings")
+    }
+  }
+
+  if (oidcSettingsIsLoading) {
+    return <CenteredSpinner />
+  }
+  if (oidcSettingsError || !oidcSettings) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading OIDC settings: ${oidcSettingsError?.message || "Unknown error"}`}
+      />
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="oidc_enabled"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel>Enable OIDC sign-in</FormLabel>
+                <FormDescription>
+                  Enable OpenID Connect authentication for your organization.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={isOidcAllowed && field.value}
+                  onCheckedChange={field.onChange}
+                  disabled={!isOidcAllowed}
+                  aria-disabled={!isOidcAllowed}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="oidc_discovery_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Discovery URL</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="https://idp.example.com/.well-known/openid-configuration"
+                  {...field}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
+              <FormDescription>
+                OIDC provider discovery endpoint.
+              </FormDescription>
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" disabled={!isOidcAllowed || updateOidcSettingsIsPending}>
+          Update OIDC settings
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -42,6 +42,7 @@ import {
   foldersUpdateFolder,
   GitSettingsRead,
   OAuthSettingsRead,
+  OIDCSettingsRead,
   organizationDeleteOrgMember,
   OrganizationDeleteOrgMemberData,
   organizationDeleteSession,
@@ -94,6 +95,7 @@ import {
   settingsGetAuthSettings,
   settingsGetGitSettings,
   settingsGetOauthSettings,
+  settingsGetOidcSettings,
   settingsGetSamlSettings,
   settingsUpdateAppSettings,
   SettingsUpdateAppSettingsData,
@@ -103,6 +105,8 @@ import {
   SettingsUpdateGitSettingsData,
   settingsUpdateOauthSettings,
   SettingsUpdateOauthSettingsData,
+  settingsUpdateOidcSettings,
+  SettingsUpdateOidcSettingsData,
   settingsUpdateSamlSettings,
   SettingsUpdateSamlSettingsData,
   TableRead,
@@ -2048,6 +2052,60 @@ export function useOrgOAuthSettings() {
     updateOAuthSettings,
     updateOAuthSettingsIsPending,
     updateOAuthSettingsError,
+  }
+}
+
+export function useOrgOidcSettings() {
+  const queryClient = useQueryClient()
+
+  const {
+    data: oidcSettings,
+    isLoading: oidcSettingsIsLoading,
+    error: oidcSettingsError,
+  } = useQuery<OIDCSettingsRead>({
+    queryKey: ["org-oidc-settings"],
+    queryFn: async () => await settingsGetOidcSettings(),
+  })
+
+  const {
+    mutateAsync: updateOidcSettings,
+    isPending: updateOidcSettingsIsPending,
+    error: updateOidcSettingsError,
+  } = useMutation({
+    mutationFn: async (params: SettingsUpdateOidcSettingsData) =>
+      await settingsUpdateOidcSettings(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-oidc-settings"] })
+      toast({
+        title: "Updated OIDC settings",
+        description: "OIDC settings updated successfully.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Failed to update OIDC settings", error)
+          toast({
+            title: "Failed to update OIDC settings",
+            description: `An error occurred while updating the OIDC settings: ${error.body.detail}`,
+          })
+      }
+    },
+  })
+
+  return {
+    oidcSettings,
+    oidcSettingsIsLoading,
+    oidcSettingsError,
+    updateOidcSettings,
+    updateOidcSettingsIsPending,
+    updateOidcSettingsError,
   }
 }
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -5,6 +5,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 from httpx_oauth.clients.google import GoogleOAuth2
+from httpx_oauth.clients.openid import OpenID
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 from sqlalchemy.exc import IntegrityError
@@ -235,6 +236,26 @@ def create_app(**kwargs) -> FastAPI:
         tags=["auth"],
         dependencies=[require_auth_type_enabled(AuthType.GOOGLE_OAUTH)],
     )
+    if config.OIDC_DISCOVERY_URL:
+        oidc_client = OpenID(
+            client_id=config.OAUTH_CLIENT_ID,
+            client_secret=config.OAUTH_CLIENT_SECRET,
+            openid_configuration_endpoint=config.OIDC_DISCOVERY_URL,
+        )
+        oidc_redirect_url = f"{config.TRACECAT__PUBLIC_APP_URL}/auth/oidc/callback"
+        app.include_router(
+            fastapi_users.get_oauth_router(
+                oidc_client,
+                auth_backend,
+                config.USER_AUTH_SECRET,
+                associate_by_email=True,
+                is_verified_by_default=True,
+                redirect_url=oidc_redirect_url,
+            ),
+            prefix="/auth/oidc",
+            tags=["auth"],
+            dependencies=[require_auth_type_enabled(AuthType.OIDC)],
+        )
     app.include_router(
         saml_router,
         dependencies=[require_auth_type_enabled(AuthType.SAML)],

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -75,7 +75,7 @@ TRACECAT__DB_POOL_RECYCLE = int(os.environ.get("TRACECAT__DB_POOL_RECYCLE", 1800
 # Infrastructure config
 TRACECAT__AUTH_TYPES = {
     AuthType(t.lower())
-    for t in os.environ.get("TRACECAT__AUTH_TYPES", "basic,google_oauth").split(",")
+    for t in os.environ.get("TRACECAT__AUTH_TYPES", "basic,google_oauth,oidc").split(",")
 }
 """The set of allowed auth types on the platform. If an auth type is not in this set,
 it cannot be enabled."""
@@ -109,6 +109,7 @@ OAUTH_CLIENT_SECRET = (
     or os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
     or ""
 )
+OIDC_DISCOVERY_URL = os.environ.get("OIDC_DISCOVERY_URL")
 USER_AUTH_SECRET = os.environ.get("USER_AUTH_SECRET", "")
 
 # SAML SSO

--- a/tracecat/settings/constants.py
+++ b/tracecat/settings/constants.py
@@ -11,4 +11,5 @@ AUTH_TYPE_TO_SETTING_KEY = {
     AuthType.BASIC: "auth_basic_enabled",
     AuthType.GOOGLE_OAUTH: "oauth_google_enabled",
     AuthType.SAML: "saml_enabled",
+    AuthType.OIDC: "oidc_enabled",
 }

--- a/tracecat/settings/models.py
+++ b/tracecat/settings/models.py
@@ -101,6 +101,22 @@ class OAuthSettingsUpdate(BaseSettingsGroup):
     )
 
 
+class OIDCSettingsRead(BaseSettingsGroup):
+    """Settings for OpenID Connect authentication."""
+
+    oidc_enabled: bool
+    oidc_discovery_url: str | None = Field(default=None)
+
+
+class OIDCSettingsUpdate(BaseSettingsGroup):
+    """Settings for OpenID Connect authentication."""
+
+    oidc_enabled: bool = Field(
+        default=False, description="Whether OIDC is enabled."
+    )
+    oidc_discovery_url: str | None = Field(default=None)
+
+
 class AppSettingsRead(BaseSettingsGroup):
     """Settings for the app."""
 

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -23,6 +23,7 @@ from tracecat.settings.models import (
     AuthSettingsUpdate,
     BaseSettingsGroup,
     GitSettingsUpdate,
+    OIDCSettingsUpdate,
     OAuthSettingsUpdate,
     SAMLSettingsUpdate,
     SettingCreate,
@@ -40,6 +41,7 @@ class SettingsService(BaseService):
         SAMLSettingsUpdate,
         AuthSettingsUpdate,
         OAuthSettingsUpdate,
+        OIDCSettingsUpdate,
         AppSettingsUpdate,
     ]
     """The set of settings groups that are managed by the service."""
@@ -261,6 +263,11 @@ class SettingsService(BaseService):
         await self._update_grouped_settings(oauth_settings, params)
 
     @require_access_level(AccessLevel.ADMIN)
+    async def update_oidc_settings(self, params: OIDCSettingsUpdate) -> None:
+        oidc_settings = await self.list_org_settings(keys=OIDCSettingsUpdate.keys())
+        await self._update_grouped_settings(oidc_settings, params)
+
+    @require_access_level(AccessLevel.ADMIN)
     async def update_app_settings(self, params: AppSettingsUpdate) -> None:
         app_settings = await self.list_org_settings(keys=AppSettingsUpdate.keys())
         await self._update_grouped_settings(app_settings, params)
@@ -338,6 +345,7 @@ def get_setting_override(key: str) -> Any | None:
         "saml_enabled",
         "oauth_google_enabled",
         "auth_basic_enabled",
+        "oidc_enabled",
     }
 
     if key not in allowed_override_keys:


### PR DESCRIPTION
## Summary
- allow configuring OIDC via env vars
- document new OIDC auth method
- support OIDC settings form and pages in the UI

## Testing
- `uv pip install --system -e .[dev]` *(fails: Python>=3.12 required)*
- `pytest -k test_organization_settings.py` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6854ff027e2483268d4b1ff0b11c5831