### PR TITLE
Add OIDC nav item

### DIFF
--- a/frontend/src/components/organization/sidebar-nav.tsx
+++ b/frontend/src/components/organization/sidebar-nav.tsx
@@ -27,6 +27,10 @@ const settingsNavItems: NavItem[] = [
     href: "/organization/settings/oauth",
   },
   {
+    title: "OIDC",
+    href: "/organization/settings/oidc",
+  },
+  {
     title: "Email authentication",
     href: "/organization/settings/auth",
   },


### PR DESCRIPTION
## Summary
- include an OIDC settings link in the organization sidebar navigation

## Testing
- `pnpm lint`
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_685531ff92e88326b53eee00c2d74ef4