### PR TITLE
Fix OIDC scope query formatting

### DIFF
--- a/frontend/src/components/auth/oidc.tsx
+++ b/frontend/src/components/auth/oidc.tsx
@@ -12,7 +12,13 @@ export function OidcSSOButton(props: OidcButtonProps) {
   const handleClick = async () => {
     try {
       setIsLoading(true)
-      const resp = await fetch(buildUrl("/auth/oidc/authorize?scopes=openid,email,profile"))
+      const params = new URLSearchParams()
+      for (const scope of ["openid", "email", "profile"]) {
+        params.append("scopes", scope)
+      }
+      const resp = await fetch(
+        buildUrl(`/auth/oidc/authorize?${params.toString()}`)
+      )
       const { authorization_url } = await resp.json()
       window.location.href = authorization_url
     } catch (error) {


### PR DESCRIPTION
## Summary
- encode OIDC scopes with repeated parameters so providers receive `openid`
- (tests still fail: ModuleNotFoundError: No module named 'minio')

## Testing
- `ruff format tracecat/api/app.py`
- `ruff check tracecat/api/app.py`
- `uv run pytest tests/unit` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_68557e2594888326af48cb3a8ab0f96b