### PR TITLE
Add OIDC client credentials support

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -6572,6 +6572,15 @@ components:
           - type: string
           - type: 'null'
           title: Oidc Discovery Url
+        oidc_client_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Oidc Client Id
+        oidc_client_secret_set:
+          type: boolean
+          title: Oidc Client Secret Set
+          readOnly: true
       type: object
       required:
       - oidc_enabled
@@ -6589,6 +6598,18 @@ components:
           - type: string
           - type: 'null'
           title: Oidc Discovery Url
+        oidc_client_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Oidc Client Id
+        oidc_client_secret:
+          anyOf:
+          - type: string
+          - type: 'null'
+          format: password
+          title: Oidc Client Secret
+          writeOnly: true
       type: object
       title: OIDCSettingsUpdate
       description: Settings for OpenID Connect authentication.


### PR DESCRIPTION
## Summary
- extend OIDC settings with client ID/secret fields
- mark oidc_client_secret as sensitive
- expose client secret state in OIDC router
- add organization settings UI for new fields
- document new behaviour
- regenerate client schemas
- test storage and encryption of client secret

## Testing
- `ruff format tracecat/settings/models.py tracecat/settings/constants.py tracecat/settings/router.py tests/unit/test_organization_settings.py`
- `ruff check tracecat/settings/models.py tracecat/settings/constants.py tracecat/settings/router.py tests/unit/test_organization_settings.py` *(fails: Found 2 errors (2 fixed, 0 remaining))*
- `pytest tests/unit/test_organization_settings.py::test_update_oidc_settings -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_685650c2da988326a423fd75e37ef4d4