### PR TITLE
Update OIDC icon

### DIFF
--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -164,7 +164,11 @@ export const Icons = {
     </svg>
   ),
   saml: (props: IconProps) => <Building2Icon {...props} />,
-  oidc: (props: IconProps) => <ShieldPlus {...props} />,
+  oidc: (props: IconProps) => (
+    <svg role="img" viewBox="0 0 24 24" {...props}>
+      <path d="M14.54.889l-3.63 1.773v18.17c-4.15-.52-7.27-2.78-7.27-5.5 0-2.58 2.8-4.75 6.63-5.41v-2.31C4.42 8.322 0 11.502 0 15.332c0 3.96 4.74 7.24 10.91 7.78l3.63-1.71V.888m.64 6.724v2.31c1.43.25 2.71.7 3.76 1.31l-1.97 1.11 7.03 1.53-.5-5.21-1.87 1.06c-1.74-1.06-3.96-1.81-6.45-2.11z" />
+    </svg>
+  ),
 }
 
 export function getFlairSize(size: "sm" | "md" | "lg"): string {


### PR DESCRIPTION
## Summary
- show the official OIDC logo on the OpenID Connect button

## Testing
- `pnpm install`
- `pnpm lint`
- `ruff check ./tracecat`
- `pytest tests/unit/test_base62.py -q` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_6857cb5381e883268ff92dcb4e043aef