### PR TITLE
Enable OIDC via env

### DIFF
--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -11,8 +11,8 @@ from tracecat.settings.constants import SENSITIVE_SETTINGS_KEYS
 from tracecat.settings.models import (
     AuthSettingsUpdate,
     GitSettingsUpdate,
-    OIDCSettingsUpdate,
     OAuthSettingsUpdate,
+    OIDCSettingsUpdate,
     SAMLSettingsUpdate,
     SettingCreate,
     SettingUpdate,

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -15,10 +15,10 @@ from tracecat.settings.models import (
     AuthSettingsUpdate,
     GitSettingsRead,
     GitSettingsUpdate,
-    OIDCSettingsRead,
-    OIDCSettingsUpdate,
     OAuthSettingsRead,
     OAuthSettingsUpdate,
+    OIDCSettingsRead,
+    OIDCSettingsUpdate,
     SAMLSettingsRead,
     SAMLSettingsUpdate,
 )

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -23,8 +23,8 @@ from tracecat.settings.models import (
     AuthSettingsUpdate,
     BaseSettingsGroup,
     GitSettingsUpdate,
-    OIDCSettingsUpdate,
     OAuthSettingsUpdate,
+    OIDCSettingsUpdate,
     SAMLSettingsUpdate,
     SettingCreate,
     SettingUpdate,
@@ -352,4 +352,12 @@ def get_setting_override(key: str) -> Any | None:
         logger.debug(f"Setting override not supported: {key}")
         return None
 
-    return os.environ.get(f"TRACECAT__SETTING_OVERRIDE_{key.upper()}")
+    env_key = f"TRACECAT__SETTING_OVERRIDE_{key.upper()}"
+    env_value = os.environ.get(env_key)
+    if env_value is not None:
+        return env_value
+
+    if key == "oidc_enabled" and config.AuthType.OIDC in config.TRACECAT__AUTH_TYPES:
+        return "true"
+
+    return None


### PR DESCRIPTION
## Summary
- auto-enable OIDC when listed in `TRACECAT__AUTH_TYPES`
- revert unit test changes

## Testing
- `ruff check .`
- `pytest --cache-clear tests/registry tests/unit tests/playbooks -x` *(fails: ModuleNotFoundError: No module named 'minio')*


------
https://chatgpt.com/codex/tasks/task_e_685842aedd9c83268e3aff8f5c508e41