### PR TITLE
Enable OIDC by default

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -6583,7 +6583,7 @@ components:
           type: boolean
           title: Oidc Enabled
           description: Whether OIDC is enabled.
-          default: false
+          default: true
         oidc_discovery_url:
           anyOf:
           - type: string

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3545,7 +3545,7 @@ export const $OIDCSettingsUpdate = {
       type: "boolean",
       title: "Oidc Enabled",
       description: "Whether OIDC is enabled.",
-      default: false,
+      default: true,
     },
     oidc_discovery_url: {
       anyOf: [{ type: "string" }, { type: "null" }],

--- a/tracecat/settings/models.py
+++ b/tracecat/settings/models.py
@@ -112,7 +112,7 @@ class OIDCSettingsUpdate(BaseSettingsGroup):
     """Settings for OpenID Connect authentication."""
 
     oidc_enabled: bool = Field(
-        default=False, description="Whether OIDC is enabled."
+        default=True, description="Whether OIDC is enabled."
     )
     oidc_discovery_url: str | None = Field(default=None)
 


### PR DESCRIPTION
## Summary
- enable OIDC by default in organization settings
- update OpenAPI schema and generated client schemas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_6858501cc5d88326b4407a19d818dbcb