### PR TITLE
Update OIDC docs

### DIFF
--- a/docs/self-hosting/authentication/oidc.mdx
+++ b/docs/self-hosting/authentication/oidc.mdx
@@ -6,10 +6,12 @@ icon: shield-keyhole
 
 ## Configuration
 
-Set `TRACECAT__AUTH_TYPES` to include `oidc`.
+OIDC is enabled by default alongside basic auth and Google OAuth.
+If you've overridden `TRACECAT__AUTH_TYPES`, ensure that `oidc`
+is included:
 
 ```bash
-TRACECAT__AUTH_TYPES=oidc
+TRACECAT__AUTH_TYPES=basic,google_oauth,oidc
 ```
 
 ## Instructions
@@ -24,6 +26,9 @@ TRACECAT__AUTH_TYPES=oidc
     - `OIDC_CLIENT_ID`
     - `OIDC_CLIENT_SECRET`
     - `OIDC_DISCOVERY_URL`
+    
+    The discovery URL usually looks like:
+    `https://<provider>/.well-known/openid-configuration`.
   </Step>
   <Step title="Restart Tracecat">
     Run `docker compose up`.


### PR DESCRIPTION
## Summary
- clarify that OIDC is enabled by default
- add note about typical discovery URL

## Testing
- `ruff check`
- `pytest tests/unit/test_organization_settings.py::test_update_oidc_settings -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68585b5a52e48326afbb973b0b352ebb