### PR TITLE
Update OIDC docs

### DIFF
--- a/docs/self-hosting/authentication/oidc.mdx
+++ b/docs/self-hosting/authentication/oidc.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenID Connect
 description: Learn how to authenticate into Tracecat using OpenID Connect.
-icon: shield-keyhole
+icon: openid
 ---
 
 ## Configuration
@@ -14,6 +14,13 @@ is included:
 TRACECAT__AUTH_TYPES=basic,google_oauth,oidc
 ```
 
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+- `OIDC_DISCOVERY_URL`
+
+The discovery URL usually looks like:
+`https://<provider>/.well-known/openid-configuration`
+
 ## Instructions
 
 <Steps>
@@ -22,13 +29,7 @@ TRACECAT__AUTH_TYPES=basic,google_oauth,oidc
     Set the redirect URL to `<your-domain>/auth/oidc/callback`.
   </Step>
   <Step title="Configure environment variables in Tracecat">
-    Set the following in your `.env` file:
-    - `OIDC_CLIENT_ID`
-    - `OIDC_CLIENT_SECRET`
-    - `OIDC_DISCOVERY_URL`
-    
-    The discovery URL usually looks like:
-    `https://<provider>/.well-known/openid-configuration`.
+    Fill in the environment variables documented above in your `.env` file.
   </Step>
   <Step title="Restart Tracecat">
     Run `docker compose up`.

--- a/docs/self-hosting/authentication/overview.mdx
+++ b/docs/self-hosting/authentication/overview.mdx
@@ -57,7 +57,7 @@ Choose from a number of authentication methods listed below to get started.
   </Card>
   <Card
     title="OpenID Connect"
-    icon="shield-keyhole"
+    icon="openid"
     href="/self-hosting/authentication/oidc"
   >
     Learn how to authenticate into Tracecat using OpenID Connect.


### PR DESCRIPTION
## Summary
- document OIDC environment variables in config section
- reference them from instructions
- show OIDC logo in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_6858db783cbc8326994deae8db760567